### PR TITLE
Staging environment indicator

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -146,7 +146,7 @@ export function NavBar({ page }: NavBarProps) {
   };
 
   const currUrl = window.location.href;
-  const isStaging = /ushs-housing-portal-staging.web.app/i.test(currUrl);
+  const isStaging = /ushs-housing-portal-staging/i.test(currUrl);
 
   return (
     <div>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -61,6 +61,14 @@ const Link = styled.a<{ active: boolean }>`
   }
 `;
 
+const StagingIndicator = styled.p`
+  text-decoration: none;
+  color: red;
+  padding: 8px 16px;
+  font-size: 24px;
+  font-weight: bold;
+`;
+
 const Overlay = styled.div`
   width: 100vw;
   height: 100vh;
@@ -137,6 +145,9 @@ export function NavBar({ page }: NavBarProps) {
       });
   };
 
+  const currUrl = window.location.href;
+  const isStaging = /ushs-housing-portal-staging.web.app/i.test(currUrl);
+
   return (
     <div>
       <NavbarItems>
@@ -148,6 +159,7 @@ export function NavBar({ page }: NavBarProps) {
           <Link href="/profile" active={page === "Profile"}>
             Profile
           </Link>
+          {isStaging && <StagingIndicator>Staging Environment</StagingIndicator>}
         </LeftWrapper>
         <LogoutButton kind="primary" onClick={togglePopup}>
           Log Out


### PR DESCRIPTION
## Tracking Info

Resolves #50 

## Changes

- Added a red text in the NavBar that indicates whether the user is in the staging environment

## Testing

I manually changed the url variable in the code to check if the text would show properly. To confirm it's working properly, I still need to test it when it's actually deployed to staging.

## Confirmation of Change

<img width="1792" alt="image" src="https://github.com/TritonSE/USHS-Housing-Portal/assets/69605985/23e67307-9ee7-4671-a511-43dd3767ba31">

