### PR TITLE
Restrict Editing Referral Status

### DIFF
--- a/frontend/src/components/ReferralTable.tsx
+++ b/frontend/src/components/ReferralTable.tsx
@@ -144,7 +144,7 @@ export const ReferralTable = (props: ReferralTableProps) => {
     updateReferral(request).catch(console.error);
   };
 
-  const HLSection = (referral: Referral) => {
+  const renderHousingLocatorCell = (referral: Referral) => {
     if (currentUser?.isHousingLocator) {
       return (
         <UserDropdown
@@ -168,6 +168,22 @@ export const ReferralTable = (props: ReferralTableProps) => {
           : "N/A"}
       </>
     );
+  };
+
+  const renderStatusCell = (referral: Referral, status: string) => {
+    if (currentUser?.isHousingLocator) {
+      return (
+        <ReferralTableDropDown
+          key={`status-select-${referral._id}`}
+          onSelect={(value) => {
+            handleUpdate(referral, value, ReferralUpdateType.Status);
+          }}
+          values={REFERRAL_STATUSES}
+          defaultValue={status}
+        />
+      );
+    }
+    return status;
   };
 
   return (
@@ -218,15 +234,8 @@ export const ReferralTable = (props: ReferralTableProps) => {
               options={allReferringStaff}
               isTableDropdown={true}
             />,
-            HLSection(referral),
-            <ReferralTableDropDown
-              key={`status-select-${idx}`}
-              onSelect={(value) => {
-                handleUpdate(referral, value, ReferralUpdateType.Status);
-              }}
-              values={REFERRAL_STATUSES}
-              defaultValue={status}
-            />,
+            renderHousingLocatorCell(referral),
+            renderStatusCell(referral, status),
             <>{formatDate(updatedAt.toString())}</>,
           ];
         })}

--- a/frontend/src/pages/RenterCandidatePage.tsx
+++ b/frontend/src/pages/RenterCandidatePage.tsx
@@ -346,7 +346,7 @@ export function RenterCandidatePage() {
     return <Loading />;
   }
 
-  const HLSection = (referral: Referral) => {
+  const renderHousingLocatorCell = (referral: Referral) => {
     if (currentUser?.isHousingLocator) {
       return (
         <UserDropdown
@@ -376,6 +376,28 @@ export function RenterCandidatePage() {
           : "N/A"}
       </>
     );
+  };
+
+  const renderStatusCell = (referral: Referral, status: string) => {
+    if (currentUser?.isHousingLocator) {
+      return (
+        <ReferralTableDropDown
+          key={referral._id}
+          values={REFERRAL_STATUSES}
+          defaultValue={status}
+          onSelect={(newStatus) => {
+            setEditReferralQuery({
+              ...editReferralQuery,
+              [referral._id]: {
+                ...editReferralQuery[referral._id],
+                status: newStatus,
+              },
+            });
+          }}
+        />
+      );
+    }
+    return status;
   };
 
   return (
@@ -575,22 +597,8 @@ export function RenterCandidatePage() {
                             }}
                             isTableDropdown={true}
                           />,
-                          HLSection(referral),
-
-                          <ReferralTableDropDown
-                            key={idx}
-                            values={REFERRAL_STATUSES}
-                            defaultValue={status}
-                            onSelect={(newStatus) => {
-                              setEditReferralQuery({
-                                ...editReferralQuery,
-                                [referral._id]: {
-                                  ...editReferralQuery[referral._id],
-                                  status: newStatus,
-                                },
-                              });
-                            }}
-                          />,
+                          renderHousingLocatorCell(referral),
+                          renderStatusCell(referral, status),
                           formatDate(updatedAt.toString()),
                           <DeleteIcon
                             key={`delete-${idx}`}


### PR DESCRIPTION

## Changes

<!-- What changes did you make? -->

Editing Referral statuses is restricted to only HLs.

This pull request includes refactoring and improvements to the `ReferralTable` component and the `RenterCandidatePage` to enhance code readability and maintainability. The main changes involve renaming functions and extracting logic into new helper functions.

Refactoring and improvements:

* [`frontend/src/components/ReferralTable.tsx`](diffhunk://#diff-f3daa0a68a3a1142dd9c63812e119e8b59293ace681940cae82b8e3f93a71a9aL147-R147): Renamed the `HLSection` function to `renderHousingLocatorCell` for better clarity and extracted the status rendering logic into a new function `renderStatusCell`. [[1]](diffhunk://#diff-f3daa0a68a3a1142dd9c63812e119e8b59293ace681940cae82b8e3f93a71a9aL147-R147) [[2]](diffhunk://#diff-f3daa0a68a3a1142dd9c63812e119e8b59293ace681940cae82b8e3f93a71a9aR173-R188) [[3]](diffhunk://#diff-f3daa0a68a3a1142dd9c63812e119e8b59293ace681940cae82b8e3f93a71a9aL221-R238)
* [`frontend/src/pages/RenterCandidatePage.tsx`](diffhunk://#diff-d3ea9a29575e57f8612cdc1628d06edb52b42b845e1bab43ba87444b1b7d4d02L349-R349): Similarly, renamed the `HLSection` function to `renderHousingLocatorCell` and created a new function `renderStatusCell` to handle the status dropdown rendering. [[1]](diffhunk://#diff-d3ea9a29575e57f8612cdc1628d06edb52b42b845e1bab43ba87444b1b7d4d02L349-R349) [[2]](diffhunk://#diff-d3ea9a29575e57f8612cdc1628d06edb52b42b845e1bab43ba87444b1b7d4d02R381-R402) [[3]](diffhunk://#diff-d3ea9a29575e57f8612cdc1628d06edb52b42b845e1bab43ba87444b1b7d4d02L578-R601)

## Testing

<!-- How did you confirm your changes worked? -->

- Manual testing
