### PR TITLE
High/Low Sort Options for Bed + Baths 

### DIFF
--- a/backend/src/services/units.ts
+++ b/backend/src/services/units.ts
@@ -145,11 +145,17 @@ export const getUnits = async (filters: FilterParams) => {
     case "2": // Newest
       sortingCriteria = "-createdAt";
       break;
-    case "3": // Bedrooms
+    case "3": // Bedrooms (High to Low)
       sortingCriteria = "-numBeds";
       break;
-    case "4": // Baths
+    case "4": // Bedrooms (Low to High)
+      sortingCriteria = "numBeds";
+      break;
+    case "5": // Baths (High to Low)
       sortingCriteria = "-numBaths";
+      break;
+    case "6": // Baths (Low to High)
+      sortingCriteria = "numBaths";
       break;
     default:
       sortingCriteria = "-monthlyRent";

--- a/frontend/src/components/SortDropDown.tsx
+++ b/frontend/src/components/SortDropDown.tsx
@@ -30,7 +30,15 @@ export type SortDropDownCompProps = {
   setValue(selected: number): void;
 };
 
-const sortOptions = ["Price (High to Low)", "Price (Low to High)", "Newest", "Bedrooms", "Baths"];
+const sortOptions = [
+  "Price (High to Low)",
+  "Price (Low to High)",
+  "Newest",
+  "Bedrooms (High to Low)",
+  "Bedrooms (Low to High)",
+  "Baths (High to Low)",
+  "Baths (Low to High)",
+];
 
 export const SortDropDownComp = (props: SortDropDownCompProps) => {
   const [isActive, setIsActive] = useState(false);


### PR DESCRIPTION
This pull request updates the sorting functionality for units in both the backend and frontend, adding more granular sorting options for bedrooms and bathrooms. The changes ensure consistency between the backend logic and the frontend dropdown options.

### Backend updates to sorting logic:

* [`backend/src/services/units.ts`](diffhunk://#diff-27f389b4879e386d79cc7a85cfc1f9b088a1b3056d3b3fab5f4d3c5c62b9ce36L148-R159): Added new sorting cases for "Bedrooms (Low to High)" and "Baths (Low to High)" to the `getUnits` function, and updated existing cases to clarify sorting order (e.g., "Bedrooms" is now "Bedrooms (High to Low)").

### Frontend updates to dropdown options:

* [`frontend/src/components/SortDropDown.tsx`](diffhunk://#diff-88461a119471eb80fa00dd5be3f4dec49727a9b60074698a9dbe6777b0d4df58L33-R41): Updated the `sortOptions` array to include new options for "Bedrooms (Low to High)" and "Baths (Low to High)", aligning with the backend changes.