### PR TITLE
Use PST for Referral Email Timestamp

### DIFF
--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -97,6 +97,7 @@ export async function sendNewReferralNotificationEmail(
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    timeZone: "America/Los_Angeles",
   });
 
   const createdByName = `${createdBy.firstName} ${createdBy.lastName}`;


### PR DESCRIPTION
This pull request includes a minor update to the `sendNewReferralNotificationEmail` function in `backend/src/services/email.ts`. The change ensures that the date formatting includes the `timeZone` property set to "America/Los_Angeles" for consistency in email notifications.